### PR TITLE
feat(survey): add stubbed survey page

### DIFF
--- a/app/[lang]/dictionaries/en-US.json
+++ b/app/[lang]/dictionaries/en-US.json
@@ -173,5 +173,19 @@
     },
     "footer_label": "Source:",
     "recently_played_template": "My most recently played song on %platform% is \"%song%\" by %artist% (played %timeAgo%).\n\nListen: %url%\n"
+  },
+  "survey": {
+    "eyebrow": "survey",
+    "heading": "Help shape this site",
+    "intro": "I'm putting together a short survey about what's useful here and what's missing. It isn't live yet — this page is a placeholder while I figure out the questions.",
+    "status_label": "status",
+    "status_value": "Stub — not yet accepting responses.",
+    "planned_label": "what I'll ask",
+    "planned_first": "How did you end up on this site?",
+    "planned_second": "What were you hoping to find?",
+    "planned_third": "What should I build or write about next?",
+    "back_label": "back to home",
+    "metadata_title": "Survey",
+    "metadata_description": "A short survey about mariolopez.org. Coming soon."
   }
 }

--- a/app/[lang]/dictionaries/es-MX.json
+++ b/app/[lang]/dictionaries/es-MX.json
@@ -173,5 +173,19 @@
     },
     "footer_label": "Código:",
     "recently_played_template": "Mi canción reproducida más recientemente en %platform% es \"%song%\" de %artist% (reproducida %timeAgo%).\n\nEscuchar: %url%\n"
+  },
+  "survey": {
+    "eyebrow": "encuesta",
+    "heading": "Ayúdame a mejorar este sitio",
+    "intro": "Estoy preparando una encuesta breve sobre qué es útil aquí y qué falta. Todavía no está activa — esta página es un placeholder mientras defino las preguntas.",
+    "status_label": "estado",
+    "status_value": "Borrador — aún no recibe respuestas.",
+    "planned_label": "qué voy a preguntar",
+    "planned_first": "¿Cómo llegaste a este sitio?",
+    "planned_second": "¿Qué esperabas encontrar?",
+    "planned_third": "¿Qué debería construir o escribir después?",
+    "back_label": "volver al inicio",
+    "metadata_title": "Encuesta",
+    "metadata_description": "Una encuesta breve sobre mariolopez.org. Muy pronto."
   }
 }

--- a/app/[lang]/survey/page.tsx
+++ b/app/[lang]/survey/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getDictionary, type Locale } from "../dictionaries";
+
+export const dynamic = "force-static";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  const dict = await getDictionary(lang as Locale);
+
+  return {
+    title: `${dict.metadata.title} | ${dict.survey.metadata_title}`,
+    description: dict.survey.metadata_description,
+  };
+}
+
+export default async function SurveyPage({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  const dict = await getDictionary(lang as Locale);
+
+  const plannedQuestions = [
+    dict.survey.planned_first,
+    dict.survey.planned_second,
+    dict.survey.planned_third,
+  ];
+
+  return (
+    <main className="min-h-screen bg-background text-foreground font-mono antialiased selection:bg-foreground/15 selection:text-foreground">
+      <div className="max-w-[680px] mx-auto px-5 sm:px-6 py-8 sm:py-10 md:py-16">
+        <header className="mb-10 md:mb-14">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-6 sm:mb-8">
+            <Link
+              href={`/${lang}`}
+              className="text-text-tertiary hover:text-foreground transition-colors"
+            >
+              ~
+            </Link>
+            <span className="text-text-decorative">/</span>
+            <span className="text-text-tertiary">{dict.survey.eyebrow}</span>
+          </div>
+
+          <h1 className="text-base sm:text-lg mb-4">{dict.survey.heading}</h1>
+          <p className="text-sm sm:text-[15px] text-muted-foreground leading-relaxed max-w-[500px]">
+            {dict.survey.intro}
+          </p>
+        </header>
+
+        <section className="mb-10 md:mb-12">
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-text-decorative select-none font-mono text-xs">#</span>
+            <h2 className="text-[11px] font-mono tracking-[0.15em] uppercase text-muted-foreground">
+              {dict.survey.status_label}
+            </h2>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+          <p className="text-sm text-text-secondary">{dict.survey.status_value}</p>
+        </section>
+
+        <section className="mb-10 md:mb-12">
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-text-decorative select-none font-mono text-xs">#</span>
+            <h2 className="text-[11px] font-mono tracking-[0.15em] uppercase text-muted-foreground">
+              {dict.survey.planned_label}
+            </h2>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+          <ol className="space-y-1">
+            {plannedQuestions.map((question, index) => (
+              <li
+                key={question}
+                className="flex items-start gap-3 py-2 text-sm text-text-secondary"
+              >
+                <span aria-hidden="true" className="w-4 shrink-0 text-text-tertiary">
+                  {index + 1}.
+                </span>
+                <span>{question}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <Link
+          href={`/${lang}`}
+          className="text-sm text-muted-foreground border-b border-border hover:text-foreground hover:border-foreground transition-colors pb-px"
+        >
+          {dict.survey.back_label}
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/scripts/check-i18n.ts
+++ b/scripts/check-i18n.ts
@@ -66,6 +66,7 @@ const USAGE_SOURCES: UsageSource[] = [
   { file: "app/[lang]/layout.tsx" },
   { file: "app/[lang]/page.tsx" },
   { file: "app/[lang]/machine/page.tsx" },
+  { file: "app/[lang]/survey/page.tsx" },
   { file: "app/[lang]/landing-page.tsx", rootPrefix: "landing", expandObjectAccesses: true },
   { file: "app/[lang]/machine/machine-page-client.tsx" },
   { file: "components/machine-content.tsx", rootPrefix: "machine", expandObjectAccesses: true },


### PR DESCRIPTION
## What

Adds a **stubbed** `/[lang]/survey` page so it can be reviewed on a Vercel preview before the real survey is built.

Preview URLs once deployed:
- `/en-US/survey`
- `/es-MX/survey`

## Why

Placeholder to get the route live and reviewable. Content is intentionally not final.

## Changes

| File | Change |
| --- | --- |
| `app/[lang]/survey/page.tsx` | New Server Component stub |
| `app/[lang]/dictionaries/en-US.json` | `survey` copy block |
| `app/[lang]/dictionaries/es-MX.json` | `survey` copy block (parity) |
| `scripts/check-i18n.ts` | Registers the page as an i18n usage source |

## Notes on conventions followed

- **Server Component**, no `"use client"` and no client JS — per repo default.
- **Styling** reuses existing theme tokens (`text-text-secondary`, `text-text-decorative`, `border-border`) and mirrors the landing page's mono/terminal layout, so light/dark both work with no new CSS.
- **Bilingual**: copy added to both dictionaries; structure parity maintained.
- **i18n audit**: the new page is registered in `USAGE_SOURCES`, so `check:i18n:strict` still reports **0 unused / 0 rewire candidates** (89 → 101 used keys). Without this the strict audit would have failed.

## Deliberately out of scope

These are follow-ups once the survey content is finalized:

- No `/machine` view counterpart yet (the repo's dual-view sync rule will apply once content is real).
- Not added to the agent markdown sitemap (`lib/agent-markdown.ts`) — that has snapshot-style tests.
- No nav/status-bar entry or route prefetching, so the page is currently only reachable by direct URL.
- No form, no submission handling, no persistence.

## Verification

- `bun run check:i18n:strict` — pass (parity PASS, 0 unused)
- `bun run build` — pass; `/en-US/survey` and `/es-MX/survey` prerendered as SSG
- `biome check` — clean on all 4 changed files

> Note: `main` currently has 2 pre-existing Biome findings in `lib/hooks/use-availability-status.ts` (import order + trailing whitespace). Left untouched to keep this PR scoped — happy to fix separately.
